### PR TITLE
fix: header misplace when no post, hashtagReact not imported

### DIFF
--- a/src/TimelinePage/TimelinePage.js
+++ b/src/TimelinePage/TimelinePage.js
@@ -6,8 +6,10 @@ import PublishBox from "../components/PublishBox";
 import AvatarImg from "../components/PublishBox/AvatarPicture";
 import useAuth from "../hooks/useAuth";
 import { provider } from "../provider/provider";
-import { AvatarAndLikeBox, ContentBox, EditAndDeleteBox, ImageSnippet, InfosSnippet,
-Loading, NoPosts, Post, PostHeader, Snippet, Timeline, TimelineContainer,TrendingBox } from "./Styleds"
+import {
+  AvatarAndLikeBox, ContentBox, EditAndDeleteBox, ImageSnippet, InfosSnippet,
+  Loading, NoPosts, Post, PostHeader, Snippet, Timeline, TimelineContainer, TrendingBox
+} from "./Styleds"
 import { Text } from "../components/ReactHashtag";
 import HashtagRanking from "../components/HashtagRanking";
 import useReload from "../hooks/useReload";
@@ -36,17 +38,17 @@ export default function TimelinePage() {
 
   if (posts.length === 0) {
     return <>
+      <Header />
       <NoPosts>
-        <Header />
         <PublishBox />
         <span>There are no posts yet</span>
       </NoPosts>
     </>
   }
   function deletePost(post) {
-    confirmDelete(post, auth); 
+    confirmDelete(post, auth);
   }
-  
+
 
   return (
     <>
@@ -71,7 +73,7 @@ export default function TimelinePage() {
                     <ion-icon name="create-outline"></ion-icon>
                   </EditAndDeleteBox>
                 </PostHeader>
-                <span>{post.text}</span>
+                <Text>{post.text}</Text>
                 <Snippet>
                   <InfosSnippet>
                     <a href={post.source} target="_blank">{post.title}</a>

--- a/src/components/Header/index.js.js
+++ b/src/components/Header/index.js.js
@@ -81,6 +81,7 @@ const Container = styled.div`
   align-items: center;
   padding: 0 17px 0 28px; 
   position:fixed;
+  z-index: 10;
 
   h1 {
     font-size: 49px;


### PR DESCRIPTION
Esse commit resolve a posição do header quando não tem postagens no site, resolve o problema da falha de import do hashtagReact na função timeline e resolve o layout do likes enquanto ao z-index do header